### PR TITLE
Move scrapling output to .scratch/jarrettmeyer/scrapling/

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.3] - 2026-03-29
+
+### Changed
+
+- `scrapling` — output directory changed from `.scrapling/` to `.scratch/jarrettmeyer/scrapling/` to match the `gan` skill convention
+
 ## [1.0.2] - 2026-03-29
 
 ### Added

--- a/plugins/jarrettmeyer/.claude-plugin/plugin.json
+++ b/plugins/jarrettmeyer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jarrettmeyer",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "description": "Utilities by Jarrett Meyer",
   "author": {
     "name": "Jarrett Meyer",

--- a/plugins/jarrettmeyer/skills/scrapling/SKILL.md
+++ b/plugins/jarrettmeyer/skills/scrapling/SKILL.md
@@ -9,19 +9,19 @@ Scrapling is an adaptive Python web scraping library that handles static pages, 
 
 ## File conventions
 
-Unless the user specifies otherwise, write all scraping files to a project-local `.scrapling/` directory:
+Unless the user specifies otherwise, write all scraping files to:
 
-- Python scripts → `.scrapling/<name>.py`
-- Output files (JSON, HTML, PDF, CSV, etc.) → `.scrapling/<name>.<ext>`
+- Python scripts → `.scratch/jarrettmeyer/scrapling/<name>.py`
+- Output files (JSON, HTML, PDF, CSV, etc.) → `.scratch/jarrettmeyer/scrapling/<name>.<ext>`
 
-This keeps scraping artifacts out of the project root.
+Ensure `.scratch/` is listed in `.gitignore` to keep scraping artifacts out of version control.
 
 ## Running scrapling
 
 Always run scripts with `uv run --with scrapling` — no installation, venv, or `pyproject.toml` required. Works in any project.
 
 ```bash
-uv run --with scrapling python .scrapling/scrape.py
+uv run --with scrapling python .scratch/jarrettmeyer/scrapling/scrape.py
 ```
 
 ## Step 1: Choose the right fetcher
@@ -155,8 +155,8 @@ class MySpider(Spider):
             yield response.follow(next_page, callback=self.parse)
 
 result = MySpider().start()
-result.items.to_json('.scrapling/output.json')
-print(f"Scraped {len(result.items)} items → .scrapling/output.json")
+result.items.to_json('.scratch/jarrettmeyer/scrapling/output.json')
+print(f"Scraped {len(result.items)} items → .scratch/jarrettmeyer/scrapling/output.json")
 ```
 
 Run with:


### PR DESCRIPTION
## Summary

- Changes scrapling's output directory from `.scrapling/` to `.scratch/jarrettmeyer/scrapling/` to match the convention established by the `gan` skill
- Adds a note to ensure `.scratch/` is in `.gitignore`
- Bumps version to `1.0.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)