### PR TITLE
fix(scrapling): correct fetcher API and scrapling[all] extra

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [1.0.4] - 2026-03-29
+
+### Fixed
+
+- `scrapling` — `StealthyFetcher` and `DynamicFetcher` examples corrected from `.get()` to `.fetch()` (closes #6)
+- `scrapling` — run command updated from `--with scrapling` to `--with "scrapling[all]"` to include browser/HTTP extras (closes #7)
+
 ## [1.0.3] - 2026-03-29
 
 ### Changed

--- a/plugins/jarrettmeyer/.claude-plugin/plugin.json
+++ b/plugins/jarrettmeyer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jarrettmeyer",
-  "version": "1.0.3",
+  "version": "1.0.4",
   "description": "Utilities by Jarrett Meyer",
   "author": {
     "name": "Jarrett Meyer",

--- a/plugins/jarrettmeyer/skills/scrapling/SKILL.md
+++ b/plugins/jarrettmeyer/skills/scrapling/SKILL.md
@@ -18,10 +18,10 @@ Ensure `.scratch/` is listed in `.gitignore` to keep scraping artifacts out of v
 
 ## Running scrapling
 
-Always run scripts with `uv run --with scrapling` — no installation, venv, or `pyproject.toml` required. Works in any project.
+Always run scripts with `uv run --with "scrapling[all]"` — no installation, venv, or `pyproject.toml` required. Works in any project.
 
 ```bash
-uv run --with scrapling python .scratch/jarrettmeyer/scrapling/scrape.py
+uv run --with "scrapling[all]" python .scratch/jarrettmeyer/scrapling/scrape.py
 ```
 
 ## Step 1: Choose the right fetcher
@@ -53,7 +53,7 @@ print(page.status)  # 200
 ```python
 from scrapling.fetchers import StealthyFetcher
 
-page = StealthyFetcher.get('https://example.com', headless=True)
+page = StealthyFetcher.fetch('https://example.com', headless=True)
 print(page.status)
 ```
 
@@ -62,7 +62,7 @@ print(page.status)
 ```python
 from scrapling.fetchers import DynamicFetcher
 
-page = DynamicFetcher.get(
+page = DynamicFetcher.fetch(
     'https://example.com',
     wait_selector='.target-element',  # wait for element before parsing
     headless=True,
@@ -162,7 +162,7 @@ print(f"Scraped {len(result.items)} items → .scratch/jarrettmeyer/scrapling/ou
 Run with:
 
 ```bash
-uv run --with scrapling python scrape.py
+uv run --with "scrapling[all]" python scrape.py
 ```
 
 ## Common options
@@ -179,10 +179,10 @@ page = Fetcher.get(
 )
 
 # DynamicFetcher: scroll before capturing
-page = DynamicFetcher.get('https://example.com', scroll_down=True)
+page = DynamicFetcher.fetch('https://example.com', scroll_down=True)
 
 # DynamicFetcher: execute JS before capturing
-page = DynamicFetcher.get(
+page = DynamicFetcher.fetch(
     'https://example.com',
     wait_selector='.loaded',
     execute_js="window.scrollTo(0, document.body.scrollHeight)",


### PR DESCRIPTION
## Summary

- Fixes `StealthyFetcher` and `DynamicFetcher` examples to use `.fetch()` instead of `.get()` — the `.get()` method doesn't exist on those classes and raises `AttributeError` at runtime
- Fixes `uv run --with scrapling` → `uv run --with "scrapling[all]"` so browser/HTTP extras (`curl_cffi`, `playwright`) are included; without them, importing `StealthyFetcher` or `DynamicFetcher` fails immediately

`Fetcher.get()` and all selector `.get()` calls (e.g. `page.css(...).get()`) are unchanged — those are correct.

## Test plan

- [x] Run a script using `StealthyFetcher.fetch(...)` with `uv run --with "scrapling[all]"` and confirm no `AttributeError` or `ModuleNotFoundError`
- [x] Confirm `Fetcher.get(...)` examples still work (HTTP verb method, not affected)
- [x] Confirm selector calls (`page.css(...).get()`) still work

Closes #7, closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)