### PR TITLE
docs(gan): document intentional signal asymmetry between phase critics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [1.0.5] - 2026-03-30
+
+### Changed
+
+- `gan` — document intentional signal asymmetry between Creation and Execution phase critics (closes #12)
+
 ## [1.0.4] - 2026-03-29
 
 ### Fixed

--- a/plugins/jarrettmeyer/.claude-plugin/plugin.json
+++ b/plugins/jarrettmeyer/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "jarrettmeyer",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "Utilities by Jarrett Meyer",
   "author": {
     "name": "Jarrett Meyer",

--- a/plugins/jarrettmeyer/skills/gan/SKILL.md
+++ b/plugins/jarrettmeyer/skills/gan/SKILL.md
@@ -169,6 +169,11 @@ Spawn a general-purpose subagent:
 6. Your response MUST begin with one of these exact signals on its own line:
    - `APPROVED`
    - `CHANGES_REQUESTED`
+
+   > **Note:** This phase intentionally uses `APPROVED`/`CHANGES_REQUESTED` (not `ACCEPTED`/`REJECTED`).
+   > The Execution Phase uses different signals because execution review differs semantically from plan review.
+   > Do not unify these signals.
+
 7. If `CHANGES_REQUESTED`: follow with a rank-ordered issue list using this format:
 
    ```
@@ -260,6 +265,11 @@ Spawn a general-purpose subagent:
 5. Your response MUST begin with:
    - `ACCEPTED`
    - `REJECTED`
+
+   > **Note:** This phase intentionally uses `ACCEPTED`/`REJECTED` (not `APPROVED`/`CHANGES_REQUESTED`).
+   > The Creation Phase uses different signals because execution review differs semantically from plan review.
+   > Do not unify these signals.
+
 6. If `REJECTED`: rank-ordered issue list. If `ACCEPTED`: brief summary.
 
 **Signal parsing:** Trim whitespace and normalise to uppercase. If the first non-blank line does


### PR DESCRIPTION
## Summary

- Adds inline notes to both Critic sections in `gan/SKILL.md` explaining that `APPROVED`/`CHANGES_REQUESTED` (Creation Phase) and `ACCEPTED`/`REJECTED` (Execution Phase) differ by design
- Notes explicitly warn against unifying the signals across phases
- Bumps version to `1.0.5` and updates `CHANGELOG.md`

Closes #12

## Test plan

- [x] Read both Critic sections in `SKILL.md` and confirm notes are present and accurate
- [x] Confirm `CHANGELOG.md` and `plugin.json` both reflect `1.0.5`

🤖 Generated with [Claude Code](https://claude.com/claude-code)