### PR TITLE
Add ca-certificates, fzf, openssl@3, pandoc, poppler to system-update key packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@
 
 - `pdf` — read, extract text from, and convert PDF files
 
+### Changed
+
+- `system-update` — update key brew packages list
+
 ## [1.0.6] - 2026-03-31
 
 ### Added

--- a/plugins/jarrettmeyer/skills/system-update/SKILL.md
+++ b/plugins/jarrettmeyer/skills/system-update/SKILL.md
@@ -49,16 +49,21 @@ Key packages:
 
 - `awscli`
 - `bash`
+- `ca-certificates`
 - `cfn-lint`
 - `coreutils`
 - `curl`
+- `fzf`
 - `gh`
 - `git`
 - `jq`
 - `node`
+- `openssl@3`
+- `pandoc`
 - `podman`
 - `podman-compose`
 - `podman-desktop`
+- `poppler`
 - `python@3.14`
 - `tree`
 - `wget`


### PR DESCRIPTION
## Summary

- Adds `ca-certificates`, `fzf`, `openssl@3`, `pandoc`, and `poppler` to the `system-update` skill's key brew packages list
- `ca-certificates` and `openssl@3` added for security reasons (CA trust store and TLS library); `fzf`, `pandoc`, `poppler` added per user request

## Test plan

- [ ] Run `/jarrettmeyer:system-update` and verify the skill still executes correctly
- [ ] Confirm newly added packages are upgraded if outdated, skipped if already current